### PR TITLE
Add PSS-78 reference scale to practical salinity funcs

### DIFF
--- a/gsw_xarray/_attributes.py
+++ b/gsw_xarray/_attributes.py
@@ -60,30 +60,37 @@ _func_attrs = {
     "SP_from_C": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SP_from_SA": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SP_from_SA_Baltic": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SP_from_SK": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SP_from_SR": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SP_from_Sstar": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SP_salinometer": {
         "standard_name": "sea_water_practical_salinity",
         "units": "1",
+        "reference_scale": "PSS-78",
     },
     "SR_from_SP": {
         "standard_name": "sea_water_reference_salinity",


### PR DESCRIPTION
This adds the OceanSITES "reference_scale" attribute with the value of "PSS-78" to the functions that return practical salinity.