### PR TITLE
Add 0.2.0 Release notes and metadata changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,33 @@
+Changelog
+=========
+
+v0.2.0 - 2022-03-22
+-------------------
+This is a major release that is ready for widespread usage.
+Our focus was on ensuring compatibility with the upstream API and a units overhaul.
+
+Highlights
+``````````
+* Upstream compatibility with package layout.
+  All the ways you can import gsw and its submodule should now Just Work.
+  This includes wildcard imports: ``from gsw_xarray import *`` and even some private members in the upstream that have leaked out.
+* All returned xr.DataArray objects will have the units attr set to the correct unit, or be "1" if the result is unitless.
+  The unit style is compatible with both UDUNITS (the CF requirement) and the python pint library.
+  Several mistakes were found in the upstream documentation, both in the python and matlab sources.
+* Functions returning practical salinity or sea water temperature will have the OceanSITES reference_scale attribute set to "PSS-78" or "ITS-90" if appropriate.
+* Some standard names assume information about the surface or geopotential that a property is being calculated against.
+  We now have some check functions that ensure the standard name is not set if one of these assumptions is not true.
+
+Breaking Changes
+````````````````
+* The attrs of the returned xr.DataArray object are now completely replaced by attrs controlled by us.
+  Previously we would only set the standard_name or units attributes and leave everything else untouched.
+  We found this to be confusing and inaccurate since the behavior of xarray would copy the attributes of the first argument to a gsw function.
+  This resulted in attributes like long_name to be incorrect.
+* The xr.DataArray.name property is now set to the return name of the gsw function.
+  For example, SA_from_SP will return a DataArray with name property set to "SA".
+
+v0.1.0 - 2021-12-15
+-------------------
+* Original release, was basically a proof of concept.
+  Only a few functions were wrapped.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents
    :maxdepth: 2
 
    attrs
+   changelog
 
 
 

--- a/gsw_xarray/__init__.py
+++ b/gsw_xarray/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from importlib import import_module
 

--- a/gsw_xarray/tests/conftest.py
+++ b/gsw_xarray/tests/conftest.py
@@ -14,3 +14,9 @@ def ds():
     ds["SA"] = ds["id"] * 0.1 + 34
     ds["SA"].attrs = {"standard_name": "sea_water_absolute_salinity"}
     return ds
+
+
+@pytest.fixture(scope="session")
+def ureg():
+    pint = pytest.importorskip("pint")
+    return pint.UnitRegistry()

--- a/gsw_xarray/tests/test_gsw_xarray.py
+++ b/gsw_xarray/tests/test_gsw_xarray.py
@@ -5,7 +5,7 @@ import pytest
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0"
 
 
 def test_func_standard(ds):

--- a/gsw_xarray/tests/test_units.py
+++ b/gsw_xarray/tests/test_units.py
@@ -6,13 +6,10 @@ import pytest
 from .test_imports import gsw_base
 from gsw_xarray._attributes import _func_attrs
 
-from pint import UnitRegistry
-
-ureg = UnitRegistry()
-
 
 @pytest.mark.parametrize("func_name", gsw_base)
-def test_unit_pint(func_name):
+def test_unit_pint(func_name, ureg):
+
     if func_name in ["indexer", "match_args_return", "pchip_interp"]:
         # Internal gsw cookery or non wrapped functions
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "gsw-xarray"
-version = "0.1.0"
-description = ""
+version = "0.2.0"
+description = "Drop in wrapper for gsw which adds CF standard name and units attributes to xarray results"
 authors = ["Andrew Barna <abarna@gmail.com>", "Romain Caneill <romain.caneill@ens-lyon.org>"]
 license = "BSD-3-Clause"
+
+readme = "README.rst"
+
+repository = "https://github.com/DocOtak/gsw-xarray"
+documentation = "https://gsw-xarray.readthedocs.io/"
 
 [tool.poetry.dependencies]
 python = ">=3.8"


### PR DESCRIPTION
Basically the title. I want the installed module to be testable by doing a ``pytest --pyargs gsw_xarray``, so I made pint optional and skip the test if not installed.

@rcaneill did I forget anything in the changelog? I'm also open to style changes if you want to suggest them.

