### PR TITLE
FIx exception in multiple return functions with non xr objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+v0.2.1 - unreleased
+-------------------
+
+Bug Fixes
+`````````
+* Fixed a bug where attributes would attempt to be be added to non xr.DataArray objects if the gsw function has multiple return values.
 
 v0.2.0 - 2022-03-22
 -------------------

--- a/gsw_xarray/_core.py
+++ b/gsw_xarray/_core.py
@@ -9,8 +9,9 @@ from ._check_funcs import _check_funcs
 
 
 def add_attrs(rv, attrs, name):
-    rv.name = name
-    rv.attrs = attrs
+    if isinstance(rv, xr.DataArray):
+        rv.name = name
+        rv.attrs = attrs
 
 
 def cf_attrs(attrs, name, check_func):
@@ -22,7 +23,7 @@ def cf_attrs(attrs, name, check_func):
             if isinstance(rv, tuple):
                 for (i, da) in enumerate(rv):
                     add_attrs(da, attrs_checked[i], name[i])
-            elif isinstance(rv, xr.DataArray):
+            else:
                 add_attrs(rv, attrs_checked, name)
             return rv
 

--- a/gsw_xarray/tests/test_gsw_xarray.py
+++ b/gsw_xarray/tests/test_gsw_xarray.py
@@ -1,6 +1,7 @@
 from gsw_xarray import __version__
 import gsw_xarray as gsw
 import xarray as xr
+import numpy as np
 import pytest
 
 
@@ -20,6 +21,12 @@ def test_func_return_tuple(ds):
     (CT_SA, CT_pt) = gsw.CT_first_derivatives(ds.SA, 1)
     assert CT_SA.name == "CT_SA"
     assert CT_SA.attrs["units"] == "K/(g/kg)"
+
+
+def test_func_return_tuple_ndarray(ds):
+    (CT_SA, CT_pt) = gsw.CT_first_derivatives(ds.SA.data, 1)
+    assert isinstance(CT_SA, np.ndarray)
+    assert isinstance(CT_pt, np.ndarray)
 
 
 @pytest.mark.parametrize("gsdh", [0, 1, None])


### PR DESCRIPTION
If the upstream gsw function returns multiple values, we were attempting to add xarray attrs without checking to see if the return values were even xarray objects.