### PR TITLE
Use defaultdict with default factory for _check_funcs

### DIFF
--- a/gsw_xarray/_check_funcs.py
+++ b/gsw_xarray/_check_funcs.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+
 def _rm_std_nme(d):
     """
     Return a dict which does not contain the standard name
@@ -9,6 +12,14 @@ def _rm_std_nme(d):
     except KeyError:
         pass
     return d
+
+
+def check_default(attrs, _kwargs):
+    """Default implimentation of the check functions
+
+    Simply returns the input attrs
+    """
+    return attrs
 
 
 def check_pot_rho_t_exact(attrs, kwargs):
@@ -57,10 +68,10 @@ def check_z_from_p(attrs, kwargs):
         return attrs
 
 
-_check_funcs = {
-    "pot_rho_t_exact": check_pot_rho_t_exact,
-    "z_from_p": check_z_from_p,
-}
+_check_funcs = defaultdict(lambda: check_default)
+
+_check_funcs["pot_rho_t_exact"] = check_pot_rho_t_exact
+_check_funcs["z_from_p"] = check_z_from_p
 
 # TODO
 # sigma1, sigma2, sigma3, sigma4

--- a/gsw_xarray/_core.py
+++ b/gsw_xarray/_core.py
@@ -171,12 +171,12 @@ def cf_attrs(fname, attrs, name, check_func):
 
 def _init_funcs():
     _wrapped_funcs = {}
-    for fname in _func_attrs.keys():
+    for fname, attrs in _func_attrs.items():
         _wrapped_funcs[fname] = cf_attrs(
             fname,
-            _func_attrs[fname],
+            attrs,
             _names[fname],
-            _check_funcs.get(fname, lambda attrs, *args, **kwargs: attrs),
+            _check_funcs[fname],
         )(getattr(gsw, fname))
     return _wrapped_funcs
 


### PR DESCRIPTION
It took me way longer than I'd care to admit to remember what that lambda was doing in the _check_func.get call.

This change hopefully makes it a little more clear what is going on.